### PR TITLE
New source unit format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+
+node_js:
+  - "5"
+
+install:
+  - mkdir $HOME/gocode
+  - export GOPATH=$HOME/gocode	
+  - export PATH=$PATH:$HOME/gocode/bin
+  - go get -u -v sourcegraph.com/sourcegraph/srclib/cmd/srclib
+  - mkdir -p $HOME/.srclib/sourcegraph.com/sourcegraph/
+  - ln -s $TRAVIS_BUILD_DIR $HOME/.srclib/sourcegraph.com/sourcegraph/srclib-typescript
+  - make
+
+script:
+  - srclib test

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -27,12 +27,6 @@ export class SourceUnit {
     Data:{
         [key: string]: any
     };
-    Config:{
-        [key: string]: any
-    };
-    Ops:{
-        [key: string]: ToolRef
-    };
 
     public static readSourceUnit(callback:(err:Error, data?:SourceUnit) => void, fd:any):void {
         var data = '';


### PR DESCRIPTION
- switching to new source unit format, removing obsolete `Ops` and `Config` following sourcegraph/srclib#293
- added Travis build script (Travis build failed now, will be addressed in a separate issue)
